### PR TITLE
:art: Code refactor :sparkles: Json persistence mechanics

### DIFF
--- a/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
+++ b/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
@@ -1,18 +1,61 @@
 package org.geminicraft.betterclaims;
 
-
-import org.geminicraft.betterclaims.command.MenuCommand;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import org.bukkit.event.Listener;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.geminicraft.betterclaims.claims.claim.data.ClaimAdapter;
 import org.geminicraft.betterclaims.events.TestInteractEvents;
 import org.mineacademy.fo.Common;
 import org.mineacademy.fo.plugin.SimplePlugin;
 
-public class MainPlugin extends SimplePlugin {
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+
+
+public class MainPlugin extends SimplePlugin implements Listener {
 
     @Override
     protected void onPluginStart() {
         Common.logFramed("BetterPlugins is starting...");
+        Gson gson = createGsonBuilder().create();
 
-        registerCommand(new MenuCommand());
-        registerEvents(new TestInteractEvents(this));
+        try {
+            this.getClaimFromJson(gson);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        registerEvents(new TestInteractEvents(this, gson));
+
+    }
+
+    private void getClaimFromJson(Gson gson) throws FileNotFoundException {
+        File file = new File(this.getDataFolder().getAbsolutePath() + "/claims.json");
+        FileReader reader = new FileReader(file);
+        JsonArray jsonArray = gson.fromJson(reader, JsonArray.class);
+
+
+        jsonArray.forEach(System.out::println);
+
+        jsonArray.forEach((arrayItem) -> {
+
+            Claim claim = gson.fromJson(arrayItem.getAsJsonObject(), Claim.class);
+
+            System.out.println(claim.toString());
+        });
+//
+
+
+    }
+
+    private GsonBuilder createGsonBuilder() {
+        final GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(Claim.class, new ClaimAdapter());
+        gsonBuilder.setPrettyPrinting();
+
+        return gsonBuilder;
     }
 }

--- a/src/main/java/org/geminicraft/betterclaims/claims/Area.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/Area.java
@@ -1,4 +1,0 @@
-package org.geminicraft.betterclaims.claims;
-
-public class Area {
-}

--- a/src/main/java/org/geminicraft/betterclaims/claims/area/Area.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/area/Area.java
@@ -1,0 +1,4 @@
+package org.geminicraft.betterclaims.claims.area;
+
+public class Area {
+}

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/Claim.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/Claim.java
@@ -8,10 +8,7 @@ import lombok.Setter;
 import org.bukkit.Location;
 import org.geminicraft.betterclaims.MainPlugin;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -22,11 +19,24 @@ public class Claim {
     private UUID ownerUUID;
     Long claimID;
 
-    @Getter
-    private List<Claim> claimList = new ArrayList<>();
 
-    public void addClaimToList(Claim claim) {
+    private static List<Claim> claimList = new ArrayList<>();
+
+    public static void addClaimToList(Claim claim) {
         claimList.add(claim);
+
+        // For testing only
+        claimList.forEach((claims) -> {
+            System.out.println(claims.toString());
+        });
+    }
+
+    public Claim() {
+    }
+
+    public Claim(UUID ownerUUID, Long claimID) {
+        this.ownerUUID = ownerUUID;
+        this.claimID = claimID;
     }
 
     public Claim(UUID ownerUUID, Long claimID, Location lesserBoundaryCorner, Location greaterBoundaryCorner) {
@@ -36,31 +46,16 @@ public class Claim {
         this.greaterBoundaryCorner = greaterBoundaryCorner;
     }
 
-    public void persistClaimToJson() throws IOException {
-        File file = new File(MainPlugin.getInstance().getDataFolder().getAbsolutePath() + "/claims.json");
-        file.getParentFile().mkdir();
-        file.createNewFile();
-        JsonArray jsonArray = new JsonArray();
-
-        claimList.forEach((claim) -> {
-            jsonArray.add(claim.write(new JsonObject()));
-        });
-
-        Writer writer = new FileWriter(file, false);
-        new Gson().toJson(jsonArray, writer);
-
-        writer.flush();
-        writer.close();
+    public UUID getOwnerUUID() {
+        return ownerUUID;
     }
 
-    // TODO: Fix encoding problem with location values.
-    public JsonObject write(JsonObject object) {
-        object.addProperty("ownerUUID", String.valueOf(ownerUUID));
-        object.addProperty("claimId", claimID);
-        object.addProperty("lesserBoundaryCorner", String.valueOf(lesserBoundaryCorner));
-        object.addProperty("greaterBoundaryCorner", String.valueOf(greaterBoundaryCorner));
+    public Long getClaimID() {
+        return claimID;
+    }
 
-        return object;
+    public static List<Claim> getClaimList() {
+        return claimList;
     }
 
     public Location getLesserBoundaryCorner() {
@@ -69,6 +64,22 @@ public class Claim {
 
     public Location getGreaterBoundaryCorner() {
         return greaterBoundaryCorner;
+    }
+
+    public void setLesserBoundaryCorner(Location lesserBoundaryCorner) {
+        this.lesserBoundaryCorner = lesserBoundaryCorner;
+    }
+
+    public void setGreaterBoundaryCorner(Location greaterBoundaryCorner) {
+        this.greaterBoundaryCorner = greaterBoundaryCorner;
+    }
+
+    public void setOwnerUUID(UUID ownerUUID) {
+        this.ownerUUID = ownerUUID;
+    }
+
+    public void setClaimID(Long claimID) {
+        this.claimID = claimID;
     }
 
     @Override

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimAdapter.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimAdapter.java
@@ -1,0 +1,59 @@
+package org.geminicraft.betterclaims.claims.claim.data;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.geminicraft.betterclaims.claims.util.ClaimLocationUtil;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class ClaimAdapter extends TypeAdapter<Claim> {
+
+    private final ClaimLocationUtil locationUtil = new ClaimLocationUtil();
+
+    @Override
+    public void write(JsonWriter jsonWriter, Claim claim) throws IOException {
+        jsonWriter.beginObject();
+        jsonWriter.name("ownerUUID").value(claim.getOwnerUUID().toString());
+        jsonWriter.name("claimId").value(claim.getClaimID());
+        jsonWriter.name("lesserBoundaryCorner").value(locationUtil.getStringLocation(claim.getLesserBoundaryCorner()));
+        jsonWriter.name("greaterBoundaryCorner").value(locationUtil.getStringLocation(claim.getGreaterBoundaryCorner()));
+        jsonWriter.endObject();
+    }
+
+    // TODO: Could definitely use a bit of code clean-up.
+    @Override
+    public Claim read(JsonReader jsonReader) throws IOException {
+        Claim claim = new Claim();
+        String propertyKey = "";
+        jsonReader.beginObject();
+
+        while(jsonReader.hasNext()) {
+            JsonToken token = jsonReader.peek();
+
+            if (token.equals(JsonToken.NAME)) {
+                propertyKey = jsonReader.nextName();
+            }
+            if ("ownerUUID".equals(propertyKey)) {
+                claim.setOwnerUUID(UUID.fromString(jsonReader.nextString()));
+                System.out.println("Got ownerUUID");
+            }
+            if ("claimId".equals(propertyKey)) {
+                claim.setClaimID(jsonReader.nextLong());
+                System.out.println("Got ClaimID");
+            }
+            if ("lesserBoundaryCorner".equals(propertyKey)) {
+                claim.setLesserBoundaryCorner(locationUtil.getLocationString(jsonReader.nextString()));
+            }
+            if ("greaterBoundaryCorner".equals(propertyKey)) {
+                claim.setGreaterBoundaryCorner(locationUtil.getLocationString(jsonReader.nextString()));
+            }
+        }
+        jsonReader.endObject();
+
+        return claim;
+    }
+}

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimPersistence.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimPersistence.java
@@ -1,0 +1,45 @@
+package org.geminicraft.betterclaims.claims.claim.data;
+
+import com.google.gson.Gson;
+import org.geminicraft.betterclaims.MainPlugin;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+public class ClaimPersistence {
+
+    private Gson gson;
+
+    public ClaimPersistence(Gson gson) {
+        this.gson = gson;
+    }
+    public void persistClaimToJson(Claim claim) throws IOException {
+        File file = new File(MainPlugin.getInstance().getDataFolder().getAbsolutePath() + "/claims.json");
+        file.getParentFile().mkdir();
+        file.createNewFile();
+
+        Writer writer = new FileWriter(file, false);
+        gson.toJson(claim, writer);
+
+        writer.flush();
+        writer.close();
+    }
+
+    public void persistClaimsToJson(List<Claim> claimList) throws IOException {
+        File file = new File(MainPlugin.getInstance().getDataFolder().getAbsolutePath() + "/claims.json");
+        file.getParentFile().mkdir();
+        file.createNewFile();
+
+        Writer writer = new FileWriter(file, true);
+        gson.toJson(claimList, writer);
+
+        writer.flush();
+        writer.close();
+    }
+
+
+}

--- a/src/main/java/org/geminicraft/betterclaims/claims/util/ClaimLocationUtil.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/util/ClaimLocationUtil.java
@@ -1,0 +1,33 @@
+package org.geminicraft.betterclaims.claims.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.mineacademy.fo.Common;
+
+public class ClaimLocationUtil {
+
+    public String getStringLocation(final Location location) {
+        return location.getWorld().getName() + " " + location.getX() + " " + location.getY() + " " + location.getZ();
+    }
+
+    public Location getLocationString(final String input) {
+        final String[] parts = input.split(" ");
+        if (parts.length == 4) {
+
+            try {
+                final World w = Bukkit.getServer().getWorld(parts[0]);
+                final double x = Double.parseDouble(parts[1]);
+                final double y = Double.parseDouble(parts[2]);
+                final double z = Double.parseDouble(parts[3]);
+
+                return new Location(w, x, y, z);
+            } catch (NumberFormatException numberFormatException) {
+                Common.log("Could not parse String to Double! Please check the file for any typo's!");
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/org/geminicraft/betterclaims/command/ClaimCommand.java
+++ b/src/main/java/org/geminicraft/betterclaims/command/ClaimCommand.java
@@ -1,0 +1,18 @@
+package org.geminicraft.betterclaims.command;
+
+import com.google.gson.Gson;
+import org.mineacademy.fo.command.SimpleCommand;
+
+public class ClaimCommand extends SimpleCommand {
+
+    private Gson gson;
+
+    protected ClaimCommand(Gson gson) {
+        super("claim");
+        this.gson = gson;
+    }
+
+    @Override
+    protected void onCommand() {
+    }
+}

--- a/src/main/java/org/geminicraft/betterclaims/events/TestInteractEvents.java
+++ b/src/main/java/org/geminicraft/betterclaims/events/TestInteractEvents.java
@@ -1,6 +1,6 @@
 package org.geminicraft.betterclaims.events;
 
-import org.bukkit.Bukkit;
+import com.google.gson.Gson;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,9 +8,8 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.geminicraft.betterclaims.MainPlugin;
-import org.geminicraft.betterclaims.claims.Area;
 import org.geminicraft.betterclaims.claims.claim.Claim;
-import org.geminicraft.betterclaims.task.VisualiserTask;
+import org.geminicraft.betterclaims.claims.claim.data.ClaimPersistence;
 import org.mineacademy.fo.Common;
 
 import java.io.IOException;
@@ -21,9 +20,11 @@ public class TestInteractEvents implements Listener {
     Location secondTestLocation = null;
 
     private MainPlugin mainPlugin;
+    private Gson gson;
 
-    public TestInteractEvents(MainPlugin mainPlugin) {
+    public TestInteractEvents(MainPlugin mainPlugin, Gson gson) {
         this.mainPlugin = mainPlugin;
+        this.gson = gson;
     }
 
     @EventHandler
@@ -57,33 +58,32 @@ public class TestInteractEvents implements Listener {
             Common.log(newArea + " area.");
 
             Claim claim = new Claim(event.getPlayer().getUniqueId(), 0L, testLocation, secondTestLocation);
-            claim.addClaimToList(claim);
-            try {
-                claim.persistClaimToJson();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            Claim.addClaimToList(claim);
 
-//            Area.createArea("hello");
-//            Claim.createClaim(event.getPlayer().getUniqueId(), 0L, testLocation, secondTestLocation);
-
-//            Claim.createClaim(event.getPlayer().getUniqueId(), 0L);
-
-//            Claim claim = new Claim(event.getPlayer().getUniqueId(), 0L);
-//            Claim claim = new Claim(event.getPlayer().getUniqueId(), 0L, testLocation, secondTestLocation);
-//            Common.tell(event.getPlayer(), claim.toString());
-//
-//            claim.getTemporaryList().add(claim);
-//
-//            claim.getTemporaryList().forEach((item -> System.out.println(claim)));
-//
 //            try {
-//                claim.saveClaimToJSON();
+//                claim.persistClaimToJson();
 //            } catch (IOException e) {
 //                e.printStackTrace();
 //            }
 
-            Bukkit.getScheduler().runTask(mainPlugin, new VisualiserTask(testLocation, secondTestLocation));
+//            String json = gson.toJson(claim);
+//            System.out.println(json);
+//
+            try {
+                new ClaimPersistence(gson).persistClaimToJson(claim);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+//            Claim jsonClaim = gson.fromJson(json, Claim.class);
+//            System.out.println(jsonClaim);
+
+//            try {
+//                claim.persistClaimToJson();
+//            } catch (IOException e) {
+//                e.printStackTrace();
+//            }
+//            Bukkit.getScheduler().runTask(mainPlugin, new VisualiserTask(testLocation, secondTestLocation));
 
             testLocation = null;
             secondTestLocation = null;


### PR DESCRIPTION
:art: Code refactor
Created a package called "data" with a ClaimPersistence class to handle persistence logic that saves to the claim.json file. It also includes a ClaimAdapter that represents the JSON Type Adapter. I've removed the write and persistence methods from the Claim class. 

✨ JSON persistence now 'works properly' at this current stage. The Location object from org.bukkit.Location is now parsed correctly to, and from, the claim.json file.