### PR TITLE
:sparkles: Created block listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 build.xml
 BetterClaims.iml
 foundation.yml
+src/main/java/org/geminicraft/betterclaims/Tests.java

--- a/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
+++ b/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
@@ -3,9 +3,13 @@ package org.geminicraft.betterclaims;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+
 import org.bukkit.event.Listener;
 import org.geminicraft.betterclaims.claims.claim.Claim;
 import org.geminicraft.betterclaims.claims.claim.data.ClaimAdapter;
+import org.geminicraft.betterclaims.command.ClaimCommand;
+import org.geminicraft.betterclaims.events.BlockPlaceListener;
+import org.geminicraft.betterclaims.events.PlayerInteractListener;
 import org.geminicraft.betterclaims.events.TestInteractEvents;
 import org.mineacademy.fo.Common;
 import org.mineacademy.fo.plugin.SimplePlugin;
@@ -13,7 +17,6 @@ import org.mineacademy.fo.plugin.SimplePlugin;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-
 
 public class MainPlugin extends SimplePlugin implements Listener {
 
@@ -28,8 +31,10 @@ public class MainPlugin extends SimplePlugin implements Listener {
             e.printStackTrace();
         }
 
-        registerEvents(new TestInteractEvents(this, gson));
-
+        registerEvents(new PlayerInteractListener());
+//        registerEvents(new TestInteractEvents(this, gson));
+        registerEvents(new BlockPlaceListener());
+        registerCommand(new ClaimCommand(gson));
     }
 
     private void getClaimFromJson(Gson gson) throws FileNotFoundException {
@@ -44,11 +49,10 @@ public class MainPlugin extends SimplePlugin implements Listener {
 
             Claim claim = gson.fromJson(arrayItem.getAsJsonObject(), Claim.class);
 
+            Claim.addClaimToList(claim);
+
             System.out.println(claim.toString());
         });
-//
-
-
     }
 
     private GsonBuilder createGsonBuilder() {

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/Claim.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/Claim.java
@@ -38,6 +38,12 @@ public class Claim {
         this.greaterBoundaryCorner = greaterBoundaryCorner;
     }
 
+    // TODO: This isn't the cleanest solution. Revisit it and clean it up.
+    public boolean contains(Location location) {
+        ClaimBoundBox boundBox = new ClaimBoundBox(this);
+        return  boundBox.contains(location);
+    }
+
     public UUID getOwnerUUID() {
         return ownerUUID;
     }

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/ClaimBoundBox.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/ClaimBoundBox.java
@@ -5,6 +5,7 @@ package org.geminicraft.betterclaims.claims.claim;
     */
 
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 
 public class ClaimBoundBox {
 
@@ -20,13 +21,17 @@ public class ClaimBoundBox {
                 location2.getBlockX(), location2.getBlockY(), location2.getBlockZ());
     }
 
-    public ClaimBoundBox(int minX, int maxX, int minY, int maxY, int minZ, int maxZ) {
+    public ClaimBoundBox(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
         this.minX = minX;
         this.maxX = maxX;
         this.minY = minY;
         this.maxY = maxY;
         this.minZ = minZ;
         this.maxZ = maxZ;
+    }
+
+    public ClaimBoundBox(Block block) {
+        this(block.getX(), block.getY(), block.getZ(), block.getX(), block.getY(), block.getZ());
     }
 
     public ClaimBoundBox(Claim claim) {
@@ -37,48 +42,24 @@ public class ClaimBoundBox {
         return minX;
     }
 
-    public void setMinX(int minX) {
-        this.minX = minX;
-    }
-
     public int getMaxX() {
         return maxX;
-    }
-
-    public void setMaxX(int maxX) {
-        this.maxX = maxX;
     }
 
     public int getMinY() {
         return minY;
     }
 
-    public void setMinY(int minY) {
-        this.minY = minY;
-    }
-
     public int getMaxY() {
         return maxY;
-    }
-
-    public void setMaxY(int maxY) {
-        this.maxY = maxY;
     }
 
     public int getMinZ() {
         return minZ;
     }
 
-    public void setMinZ(int minZ) {
-        this.minZ = minZ;
-    }
-
     public int getMaxZ() {
         return maxZ;
-    }
-
-    public void setMaxZ(int maxZ) {
-        this.maxZ = maxZ;
     }
 
     public boolean contains(Claim claim) {
@@ -87,15 +68,14 @@ public class ClaimBoundBox {
                 this.getMinZ() >= minX && this.getMaxZ() < maxX;
     }
 
-
     public boolean contains(Location location) {
         return contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
     }
 
     public boolean contains(int x, int y, int z) {
-        return x >= minX && x <= maxX &&
-                y >= minY && y <= maxY &&
-                z >= minZ && z <= maxZ;
+        return x <= minX && x >= maxX &&
+                y <= minY && y >= maxY &&
+                z <= minZ && z >= maxZ;
     }
 
     public boolean overlaps(Claim claim) {
@@ -103,5 +83,15 @@ public class ClaimBoundBox {
                 minZ > this.getMaxX() || minY > this.getMaxY() || minZ > this.getMaxZ());
     }
 
-
+    @Override
+    public String toString() {
+        return "ClaimBoundBox{" +
+                "minX=" + minX +
+                ", maxX=" + maxX +
+                ", minY=" + minY +
+                ", maxY=" + maxY +
+                ", minZ=" + minZ +
+                ", maxZ=" + maxZ +
+                '}';
+    }
 }

--- a/src/main/java/org/geminicraft/betterclaims/command/ClaimCommand.java
+++ b/src/main/java/org/geminicraft/betterclaims/command/ClaimCommand.java
@@ -1,18 +1,27 @@
 package org.geminicraft.betterclaims.command;
 
 import com.google.gson.Gson;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.permissions.PermissionAttachment;
+import org.geminicraft.betterclaims.MainPlugin;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.geminicraft.betterclaims.task.VisualiserTask;
 import org.mineacademy.fo.command.SimpleCommand;
 
 public class ClaimCommand extends SimpleCommand {
 
     private Gson gson;
 
-    protected ClaimCommand(Gson gson) {
+    public ClaimCommand(Gson gson) {
         super("claim");
         this.gson = gson;
     }
-
     @Override
     protected void onCommand() {
+       Claim.getClaimList().forEach((claim -> {
+           Bukkit.getScheduler().runTask(MainPlugin.getInstance(), new VisualiserTask(claim.getLesserBoundaryCorner(), claim.getGreaterBoundaryCorner()));
+       }));
     }
 }

--- a/src/main/java/org/geminicraft/betterclaims/events/BlockPlaceListener.java
+++ b/src/main/java/org/geminicraft/betterclaims/events/BlockPlaceListener.java
@@ -1,0 +1,64 @@
+package org.geminicraft.betterclaims.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.mineacademy.fo.Common;
+
+import java.util.List;
+
+
+public class BlockPlaceListener implements Listener {
+
+    // TODO: Temporary access with Lombok, clean up with next refactor.
+    @Getter
+    @Setter
+    Claim lastClaim = null;
+
+    // TODO: Move elsewhere and refactor to be more efficient as it's currently O(n^2)
+    // TODO Generalised method can be moved to its own class.
+    private Claim getClaim(Location blockLocation, Claim lastClaim) {
+        if (lastClaim != null && lastClaim.contains(blockLocation)) {
+            return lastClaim;
+        }
+
+        List<Claim> claimList = Claim.getClaimList();
+
+        for (Claim claim : claimList) {
+            if (claim.contains(blockLocation)) {
+                this.setLastClaim(claim);
+                return claim;
+            }
+        }
+        return null;
+    }
+
+    // TODO Generalised method can be moved to its own class.
+    private boolean isPlayerAllowedToBuild(Location location, Player player) {
+        Claim claim = getClaim(location, this.getLastClaim());
+
+        if (claim == null) {
+            Common.tell(player, "&6This is probably the wilderness!");
+            return true;
+        }
+        return claim.getOwnerUUID().equals(player.getUniqueId());
+    }
+
+    @EventHandler
+    public void onBlockPlace(final BlockPlaceEvent event) {
+        final Player player = event.getPlayer();
+        final Block block = event.getBlock();
+        final Location blockLocation = block.getLocation();
+
+        if (!isPlayerAllowedToBuild(blockLocation, player)) {
+            event.setBuild(false);
+            Common.tell(player, "&cYou can't build here.");
+        }
+    }
+}

--- a/src/main/java/org/geminicraft/betterclaims/events/TestInteractEvents.java
+++ b/src/main/java/org/geminicraft/betterclaims/events/TestInteractEvents.java
@@ -1,6 +1,7 @@
 package org.geminicraft.betterclaims.events;
 
 import com.google.gson.Gson;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -10,6 +11,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.geminicraft.betterclaims.MainPlugin;
 import org.geminicraft.betterclaims.claims.claim.Claim;
 import org.geminicraft.betterclaims.claims.claim.data.ClaimPersistence;
+import org.geminicraft.betterclaims.task.VisualiserTask;
 import org.mineacademy.fo.Common;
 
 import java.io.IOException;
@@ -83,7 +85,6 @@ public class TestInteractEvents implements Listener {
 //            } catch (IOException e) {
 //                e.printStackTrace();
 //            }
-//            Bukkit.getScheduler().runTask(mainPlugin, new VisualiserTask(testLocation, secondTestLocation));
 
             testLocation = null;
             secondTestLocation = null;


### PR DESCRIPTION
:sparkles: Created a BlockPlaceListener to detect whether a player can build in a claim, or not and whether it's actually a claim. If it isn't a claim, then the player is probably in the open wilderness area. For now, I allow players to build there by default.

Currently, the method to get a Claim is expensive and can cause problems. A solution will be implemented when other block and player events are created.