### PR TITLE
:sparkles: Block fluids handled :sparkles: Prevent block transform

### DIFF
--- a/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
+++ b/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
@@ -4,13 +4,13 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.event.Listener;
 import org.geminicraft.betterclaims.claims.claim.Claim;
 import org.geminicraft.betterclaims.claims.claim.data.ClaimAdapter;
 import org.geminicraft.betterclaims.command.ClaimCommand;
-import org.geminicraft.betterclaims.events.BlockBreakListener;
-import org.geminicraft.betterclaims.events.BlockPlaceListener;
-import org.geminicraft.betterclaims.events.TestInteractEvents;
+import org.geminicraft.betterclaims.events.*;
 import org.mineacademy.fo.Common;
 import org.mineacademy.fo.plugin.SimplePlugin;
 
@@ -34,6 +34,8 @@ public class MainPlugin extends SimplePlugin implements Listener {
 //        registerEvents(new TestInteractEvents(this, gson));
         registerEvents(new BlockPlaceListener());
         registerEvents(new BlockBreakListener());
+        registerEvents(new BlockFormListener());
+        registerEvents(new BlockFluidListener());
         registerCommand(new ClaimCommand(gson));
     }
 

--- a/src/main/java/org/geminicraft/betterclaims/events/BlockFluidListener.java
+++ b/src/main/java/org/geminicraft/betterclaims/events/BlockFluidListener.java
@@ -1,0 +1,33 @@
+package org.geminicraft.betterclaims.events;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.geminicraft.betterclaims.claims.util.ClaimLocationUtil;
+
+public class BlockFluidListener implements Listener {
+
+    private Claim lastSpreadClaim = null;
+
+    @EventHandler
+    public void onBlockForm(final BlockFromToEvent event) {
+        if (event.getFace() == BlockFace.DOWN) return;
+
+        final Block toBlock = event.getToBlock();
+        Claim claim = ClaimLocationUtil.getClaim(toBlock.getLocation(), lastSpreadClaim);
+
+        if (claim != null) {
+            this.lastSpreadClaim = claim;
+            final Block block = event.getBlock();
+
+            if (!claim.contains(block.getLocation())) {
+                event.setCancelled(true);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/geminicraft/betterclaims/events/BlockFormListener.java
+++ b/src/main/java/org/geminicraft/betterclaims/events/BlockFormListener.java
@@ -1,0 +1,37 @@
+package org.geminicraft.betterclaims.events;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFormEvent;
+import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.geminicraft.betterclaims.claims.util.ClaimLocationUtil;
+
+public class BlockFormListener implements Listener {
+
+    private static final ImmutableSet<Material> BLOCK_FORM_MATERIAL = Sets.immutableEnumSet(
+            Material.COBBLESTONE,
+            Material.OBSIDIAN,
+            Material.LAVA,
+            Material.WATER
+    );
+
+    private boolean isBlockedMaterial(final Material material) {
+        return BLOCK_FORM_MATERIAL.contains(material);
+    }
+
+    @EventHandler
+    public void onBlockForm(final BlockFormEvent event) {
+        final Block block = event.getBlock();
+
+        if (isBlockedMaterial(block.getType())) {
+            Claim claim = ClaimLocationUtil.getClaim(block.getLocation(), null);
+            if (claim == null) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
:sparkles: Prevent block fluids like lava and water from going into a claim.

:sparkles: Prevent blocks from being transformed to obsidian/cobblestone outside of a claim. 
Please note this last feature is probably going to be moved out of this plugin in favor of putting this in a different plugin. 