### PR TITLE
:sparkles: Separated Claims to different files

### DIFF
--- a/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
+++ b/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
@@ -3,18 +3,16 @@ package org.geminicraft.betterclaims;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-
 import org.bukkit.event.Listener;
 import org.geminicraft.betterclaims.claims.claim.Claim;
 import org.geminicraft.betterclaims.claims.claim.data.ClaimAdapter;
 import org.geminicraft.betterclaims.command.ClaimCommand;
-
 import org.geminicraft.betterclaims.listeners.blocks.*;
-
 import org.geminicraft.betterclaims.listeners.player.PlayerEmptyBucketListener;
 import org.geminicraft.betterclaims.listeners.player.PlayerInteractListener;
 import org.geminicraft.betterclaims.listeners.player.PlayerSheerEntityListener;
 import org.mineacademy.fo.Common;
+import org.mineacademy.fo.FileUtil;
 import org.mineacademy.fo.plugin.SimplePlugin;
 
 import java.io.File;
@@ -29,7 +27,7 @@ public class MainPlugin extends SimplePlugin implements Listener {
         Gson gson = createGsonBuilder().create();
 
         try {
-            this.getClaimFromJson(gson);
+            this.getClaimsFromJson(gson);
         } catch (FileNotFoundException e) {
             e.printStackTrace();
         }
@@ -64,6 +62,19 @@ public class MainPlugin extends SimplePlugin implements Listener {
 
             System.out.println(claim.toString());
         });
+    }
+
+    private void getClaimsFromJson(Gson gson) throws FileNotFoundException {
+        FileReader reader;
+
+        for (File file : FileUtil.getFiles("ClaimData", ".json")) {
+            reader = new FileReader(file);
+
+            Claim claim = gson.fromJson(reader, Claim.class);
+            Claim.addClaimToList(claim);
+
+            System.out.println("[ALERT] Here is thy claim: " + claim);
+        }
     }
 
     private GsonBuilder createGsonBuilder() {

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimPersistence.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimPersistence.java
@@ -1,6 +1,7 @@
 package org.geminicraft.betterclaims.claims.claim.data;
 
 import com.google.gson.Gson;
+
 import org.geminicraft.betterclaims.MainPlugin;
 import org.geminicraft.betterclaims.claims.claim.Claim;
 
@@ -8,17 +9,20 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.List;
 
 public class ClaimPersistence {
 
     private Gson gson;
 
+    private final String PATH = MainPlugin.getInstance().getDataFolder().getAbsolutePath() + "/ClaimData/";
+
     public ClaimPersistence(Gson gson) {
         this.gson = gson;
     }
-    public void persistClaimToJson(Claim claim) throws IOException {
-        File file = new File(MainPlugin.getInstance().getDataFolder().getAbsolutePath() + "/claims.json");
+
+    public void createClaimAsJson(Claim claim) throws IOException {
+        // TODO: This is a constant path for now, creating claims manually is not yet implemented.
+        File file = new File(PATH + "claim_id_0.json");
         file.getParentFile().mkdir();
         file.createNewFile();
 
@@ -29,17 +33,13 @@ public class ClaimPersistence {
         writer.close();
     }
 
-    public void persistClaimsToJson(List<Claim> claimList) throws IOException {
-        File file = new File(MainPlugin.getInstance().getDataFolder().getAbsolutePath() + "/claims.json");
-        file.getParentFile().mkdir();
-        file.createNewFile();
+    // TODO Update a claim - consider changing this to be more explicit: 'What are we updating? What properties? And maybe even 'why'?'
+    public void updateClaim(Claim claim) {
 
-        Writer writer = new FileWriter(file, true);
-        gson.toJson(claimList, writer);
-
-        writer.flush();
-        writer.close();
     }
 
+    // TODO: Delete a claim
+    public void deleteClaim(Claim claim) {
 
+    }
 }

--- a/src/main/java/org/geminicraft/betterclaims/listeners/TestInteractEvents.java
+++ b/src/main/java/org/geminicraft/betterclaims/listeners/TestInteractEvents.java
@@ -70,7 +70,7 @@ public class TestInteractEvents implements Listener {
 //            System.out.println(json);
 //
             try {
-                new ClaimPersistence(gson).persistClaimToJson(claim);
+                new ClaimPersistence(gson).createClaimAsJson(claim);
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
:sparkles: Previously, all the claims would be stored in a single 'Claims.json' file. It was always intended to be a temporary file before implementing other properties like groups and users.  