### PR TITLE
:sparkles: Created player groups :poop: Requires code update

### DIFF
--- a/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
+++ b/src/main/java/org/geminicraft/betterclaims/MainPlugin.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Listener;
 import org.geminicraft.betterclaims.claims.claim.Claim;
 import org.geminicraft.betterclaims.claims.claim.data.ClaimAdapter;
 import org.geminicraft.betterclaims.command.ClaimCommand;
+import org.geminicraft.betterclaims.listeners.TestInteractEvents;
 import org.geminicraft.betterclaims.listeners.blocks.*;
 import org.geminicraft.betterclaims.listeners.player.PlayerEmptyBucketListener;
 import org.geminicraft.betterclaims.listeners.player.PlayerInteractListener;
@@ -32,16 +33,16 @@ public class MainPlugin extends SimplePlugin implements Listener {
             e.printStackTrace();
         }
 
-//        registerEvents(new TestInteractEvents(this, gson));
+        registerEvents(new TestInteractEvents(this, gson));
         registerEvents(new BlockPlaceListener());
         registerEvents(new BlockBreakListener());
         registerEvents(new BlockFormListener());
         registerEvents(new BlockFluidListener());
         registerEvents(new StructureGrowListener());
 
-        registerEvents(new PlayerInteractListener());
-        registerEvents(new PlayerSheerEntityListener());
-        registerEvents(new PlayerEmptyBucketListener());
+//        registerEvents(new PlayerInteractListener());
+//        registerEvents(new PlayerSheerEntityListener());
+//        registerEvents(new PlayerEmptyBucketListener());
 
         registerCommand(new ClaimCommand(gson));
     }

--- a/src/main/java/org/geminicraft/betterclaims/claims/area/Area.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/area/Area.java
@@ -1,4 +1,0 @@
-package org.geminicraft.betterclaims.claims.area;
-
-public class Area {
-}

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/Claim.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/Claim.java
@@ -3,39 +3,31 @@ package org.geminicraft.betterclaims.claims.claim;
 import org.bukkit.Location;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class Claim {
 
-    Location lesserBoundaryCorner, greaterBoundaryCorner;
+    private Location lesserBoundaryCorner, greaterBoundaryCorner;
     private UUID ownerUUID;
-    Long claimID;
-
+    private Long claimID;
+    private Set<ClaimGroup> claimGroup;
 
     private static List<Claim> claimList = new ArrayList<>();
 
     public static void addClaimToList(Claim claim) {
         claimList.add(claim);
-
-        // For testing only
-        claimList.forEach((claims) -> {
-            System.out.println(claims.toString());
-        });
     }
 
     public Claim() {
     }
 
-    public Claim(UUID ownerUUID, Long claimID) {
-        this.ownerUUID = ownerUUID;
-        this.claimID = claimID;
-    }
-
-    public Claim(UUID ownerUUID, Long claimID, Location lesserBoundaryCorner, Location greaterBoundaryCorner) {
+    public Claim(UUID ownerUUID, Long claimID, Location lesserBoundaryCorner, Location greaterBoundaryCorner, Set<ClaimGroup> claimGroups) {
         this.ownerUUID = ownerUUID;
         this.claimID = claimID;
         this.lesserBoundaryCorner = lesserBoundaryCorner;
         this.greaterBoundaryCorner = greaterBoundaryCorner;
+        this.claimGroup = claimGroups;
     }
 
     // TODO: This isn't the cleanest solution. Revisit it and clean it up.
@@ -80,14 +72,24 @@ public class Claim {
         this.claimID = claimID;
     }
 
+    public Set<ClaimGroup> getClaimGroup() {
+        return claimGroup;
+    }
+
+    public void setClaimGroup(Set<ClaimGroup> claimGroup) {
+        this.claimGroup = claimGroup;
+    }
+
     @Override
     public String toString() {
         return "Claim{" +
-                "ownerUUID=" + ownerUUID +
+                "lesserBoundaryCorner=" + lesserBoundaryCorner +
+                ", greaterBoundaryCorner=" + greaterBoundaryCorner +
+                ", ownerUUID=" + ownerUUID +
                 ", claimID=" + claimID +
-                ", lesserLocation" + lesserBoundaryCorner +
-                ", greaterLocation" + greaterBoundaryCorner +
+                ", claimGroup=" + claimGroup +
                 '}';
     }
+
 
 }

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/ClaimGroup.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/ClaimGroup.java
@@ -1,0 +1,64 @@
+package org.geminicraft.betterclaims.claims.claim;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class ClaimGroup {
+
+    private String name;
+
+    private Location spawnLocation;
+
+    private ChatColor chatColor;
+
+    private Set<String> permissions = new HashSet<>();
+
+    private Set<UUID> playerUUIDs = new HashSet<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Location getSpawnLocation() {
+        return spawnLocation;
+    }
+
+    public void setSpawnLocation(Location spawnLocation) {
+        this.spawnLocation = spawnLocation;
+    }
+
+    public ChatColor getChatColor() {
+        return chatColor;
+    }
+
+    public void setChatColor(ChatColor chatColor) {
+        this.chatColor = chatColor;
+    }
+
+    public Set<String> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(Set<String> permissions) {
+        this.permissions = permissions;
+    }
+
+    public Set<UUID> getPlayerUUIDs() {
+        return playerUUIDs;
+    }
+
+    public void setPlayerUUIDs(Set<UUID> playerUUIDs) {
+        this.playerUUIDs = playerUUIDs;
+    }
+
+
+}

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimAdapter.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimAdapter.java
@@ -2,54 +2,150 @@ package org.geminicraft.betterclaims.claims.claim.data;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.geminicraft.betterclaims.claims.claim.Claim;
+import org.geminicraft.betterclaims.claims.claim.ClaimGroup;
 import org.geminicraft.betterclaims.claims.util.ClaimLocationStringUtil;
 
 import java.io.IOException;
-import java.util.UUID;
+import java.util.*;
 
 public class ClaimAdapter extends TypeAdapter<Claim> {
 
     private final ClaimLocationStringUtil locationUtil = new ClaimLocationStringUtil();
 
+    Set<ClaimGroup> groupList = new HashSet<>();
+
+    private void createGroup(String name, Location location, ChatColor chatColor, Set<String> permissions) {
+        ClaimGroup claimGroup = new ClaimGroup();
+        claimGroup.setName(name);
+        claimGroup.setSpawnLocation(location);
+        claimGroup.setChatColor(chatColor);
+        claimGroup.setPermissions(permissions);
+        claimGroup.setPlayerUUIDs(new HashSet<>(Arrays.asList(UUID.fromString("3457f4bf-3616-4da2-aa1d-017b36f86662"))));
+
+        groupList.add(claimGroup);
+    }
+
     @Override
     public void write(JsonWriter jsonWriter, Claim claim) throws IOException {
+
+
+        this.createGroup("Trusted",
+                new Location(Bukkit.getWorld("world"), 0, 0, 0),
+                ChatColor.GOLD,
+                new HashSet<>(Arrays.asList(
+                        "claim.can.chat",
+                        "claim.can.teleport",
+                        "claim.can.break.blocks",
+                        "claim.can.place.blocks"
+                )));
+
+
+
+
         jsonWriter.beginObject();
+
         jsonWriter.name("ownerUUID").value(claim.getOwnerUUID().toString());
         jsonWriter.name("claimId").value(claim.getClaimID());
         jsonWriter.name("lesserBoundaryCorner").value(locationUtil.getStringLocation(claim.getLesserBoundaryCorner()));
         jsonWriter.name("greaterBoundaryCorner").value(locationUtil.getStringLocation(claim.getGreaterBoundaryCorner()));
+
+        jsonWriter.name("groups").beginArray();
+        for (ClaimGroup group : groupList) {
+            jsonWriter.beginObject();
+            jsonWriter.name("name").value(group.getName());
+            jsonWriter.name("spawnLocation").value(locationUtil.getStringLocation(group.getSpawnLocation()));
+            jsonWriter.name("color").value(group.getChatColor().name());
+
+            jsonWriter.name("players").beginArray();
+            for (UUID playerUUID : group.getPlayerUUIDs()) {
+                jsonWriter.value(playerUUID.toString());
+            }
+            jsonWriter.endArray();
+
+            jsonWriter.name("permissions").beginArray();
+            for (String permission : group.getPermissions()) {
+                jsonWriter.value(permission);
+            }
+            jsonWriter.endArray();
+
+            jsonWriter.endObject();
+        }
+
+        jsonWriter.endArray();
+
         jsonWriter.endObject();
     }
 
-    // TODO: Could definitely use a bit of code clean-up.
+    // TODO: This code isn't clean and it's a priority to clean it up.
     @Override
     public Claim read(JsonReader jsonReader) throws IOException {
         Claim claim = new Claim();
-        String propertyKey = "";
+
         jsonReader.beginObject();
+        while (jsonReader.hasNext()) {
+            switch (jsonReader.nextName()) {
+                case "ownerUUID":
+                    claim.setOwnerUUID(UUID.fromString(jsonReader.nextString()));
+                    break;
+                case "claimId":
+                    claim.setClaimID(jsonReader.nextLong());
+                    break;
+                case "lesserBoundaryCorner":
+                    claim.setLesserBoundaryCorner(locationUtil.getLocationString(jsonReader.nextString()));
+                    break;
+                case "greaterBoundaryCorner":
+                    claim.setGreaterBoundaryCorner(locationUtil.getLocationString(jsonReader.nextString()));
+                    break;
+                case "groups":
+                    jsonReader.beginArray();
+                    Set<ClaimGroup> claimGroups = new HashSet<>();
+                    while (jsonReader.hasNext()) {
+                        jsonReader.beginObject();
+                        ClaimGroup claimGroup = new ClaimGroup();
 
-        while(jsonReader.hasNext()) {
-            JsonToken token = jsonReader.peek();
+                        while (jsonReader.hasNext()) {
+                            switch (jsonReader.nextName()) {
+                                case "name":
+                                    claimGroup.setName(jsonReader.nextString());
+                                    break;
+                                case "spawnLocation":
+                                    claimGroup.setSpawnLocation(locationUtil.getLocationString(jsonReader.nextString()));
+                                    break;
+                                case "color":
+                                    claimGroup.setChatColor(ChatColor.valueOf(jsonReader.nextString()));
+                                    break;
 
-            if (token.equals(JsonToken.NAME)) {
-                propertyKey = jsonReader.nextName();
-            }
-            if ("ownerUUID".equals(propertyKey)) {
-                claim.setOwnerUUID(UUID.fromString(jsonReader.nextString()));
-                System.out.println("Got ownerUUID");
-            }
-            if ("claimId".equals(propertyKey)) {
-                claim.setClaimID(jsonReader.nextLong());
-                System.out.println("Got ClaimID");
-            }
-            if ("lesserBoundaryCorner".equals(propertyKey)) {
-                claim.setLesserBoundaryCorner(locationUtil.getLocationString(jsonReader.nextString()));
-            }
-            if ("greaterBoundaryCorner".equals(propertyKey)) {
-                claim.setGreaterBoundaryCorner(locationUtil.getLocationString(jsonReader.nextString()));
+                                case "players":
+                                    jsonReader.beginArray();
+                                    Set<UUID> playerUUIDs = new HashSet<>();
+                                    while (jsonReader.hasNext()) {
+                                        playerUUIDs.add(UUID.fromString(jsonReader.nextString()));
+                                    }
+                                    claimGroup.setPlayerUUIDs(playerUUIDs);
+                                    jsonReader.endArray();
+                                    break;
+                                case "permissions":
+                                    jsonReader.beginArray();
+                                    Set<String> permissions = new HashSet<>();
+                                    while (jsonReader.hasNext()) {
+                                        permissions.add(jsonReader.nextString());
+                                    }
+                                    claimGroup.setPermissions(permissions);
+                                    jsonReader.endArray();
+                                    break;
+                            }
+                        }
+                        jsonReader.endObject();
+                        claimGroups.add(claimGroup);
+
+                    }
+                    claim.setClaimGroup(claimGroups);
+                    jsonReader.endArray();
             }
         }
         jsonReader.endObject();

--- a/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimPersistence.java
+++ b/src/main/java/org/geminicraft/betterclaims/claims/claim/data/ClaimPersistence.java
@@ -22,7 +22,7 @@ public class ClaimPersistence {
 
     public void createClaimAsJson(Claim claim) throws IOException {
         // TODO: This is a constant path for now, creating claims manually is not yet implemented.
-        File file = new File(PATH + "claim_id_0.json");
+        File file = new File(PATH + "claim_id_2.json");
         file.getParentFile().mkdir();
         file.createNewFile();
 

--- a/src/main/java/org/geminicraft/betterclaims/listeners/TestInteractEvents.java
+++ b/src/main/java/org/geminicraft/betterclaims/listeners/TestInteractEvents.java
@@ -57,7 +57,7 @@ public class TestInteractEvents implements Listener {
             int newArea = width * length;
             Common.log(newArea + " area.");
 
-            Claim claim = new Claim(event.getPlayer().getUniqueId(), 0L, testLocation, secondTestLocation);
+            Claim claim = new Claim(event.getPlayer().getUniqueId(), 0L, testLocation, secondTestLocation, null);
             Claim.addClaimToList(claim);
 
 //            try {


### PR DESCRIPTION
:sparkles: Created player groups. A claim can now have a group with a set of permissions. Players can be assigned to that group to share those permissions. This pull request only creates the groups in the JSON files. We don't do anything practical with this new functionality just yet.

:poop: TypeAdapter is a bit awkward to use. The code I've written isn't 'clean' in the slightest. This is not intentional but just lacking in an understanding of how to write clean code with TypeAdapter<T>'s methods. 
As it currently stands, this code 'works' and should be updated once a better understanding is gained on how to write a cleaner solution for this code.